### PR TITLE
Add ConfirmationDescription Enum

### DIFF
--- a/src/main/java/uk/gov/companieshouse/transactions/web/confirmation/ConfirmationDescription.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/confirmation/ConfirmationDescription.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.transactions.web.confirmation;
+
+import java.util.Arrays;
+import uk.gov.companieshouse.transactions.web.exception.UnsupportedTransactionConfirmationException;
+
+/**
+ * Provides a mapping between a transaction description and its confirmation description
+ */
+public enum ConfirmationDescription {
+
+    FULL_ACCOUNTS("Small Full Accounts", "Full accounts");
+
+    private String transactionDescription;
+    private String confirmationDescription;
+
+    ConfirmationDescription(String transactionDescription, String confirmationDescription) {
+        this.transactionDescription = transactionDescription;
+        this.confirmationDescription = confirmationDescription;
+    }
+
+    public String getTransactionDescription() {
+        return transactionDescription;
+    }
+
+    public String getConfirmationDescription() {
+        return confirmationDescription;
+    }
+
+    /**
+     * Retrieve a confirmation description for a given transaction description
+     * @param transactionDescription The description field on the transaction
+     * @return a confirmation description
+     */
+    public static String getConfirmationDescription(String transactionDescription)
+                                    throws UnsupportedTransactionConfirmationException {
+
+        return Arrays.stream(ConfirmationDescription.values())
+                .filter(e -> e.getTransactionDescription().equalsIgnoreCase(transactionDescription))
+                .findFirst()
+                .orElseThrow(() ->
+                        new UnsupportedTransactionConfirmationException("No confirmation description "
+                                + "mapping for transaction description: " + transactionDescription))
+                .getConfirmationDescription();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/transactions/web/exception/UnsupportedTransactionConfirmationException.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/exception/UnsupportedTransactionConfirmationException.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.transactions.web.exception;
+
+/**
+ * The class {@code UnsupportedTransactionConfirmationException} is a form of {@code Exception}
+ * which is thrown if a transaction cannot be mapped to a {@code Confirmation} model
+ */
+public class UnsupportedTransactionConfirmationException extends Exception {
+
+    /**
+     * Constructs a new {@code UnsupportedTransactionConfirmationException} with a custom message
+     * @param message The custom message
+     */
+    public UnsupportedTransactionConfirmationException(String message) {
+        super(message);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/transactions/web/confirmation/ConfirmationDescriptionTests.java
+++ b/src/test/java/uk/gov/companieshouse/transactions/web/confirmation/ConfirmationDescriptionTests.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.transactions.web.confirmation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.transactions.web.exception.UnsupportedTransactionConfirmationException;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ConfirmationDescriptionTests {
+
+    @Test
+    @DisplayName("Get Confirmation Description - Valid Transaction Description")
+    void getConfirmationDescriptionSuccess() throws UnsupportedTransactionConfirmationException {
+
+        String validTransactionDescription = "Small Full Accounts";
+
+        String expectedConfirmationDesction = "Full accounts";
+
+        String confirmationDescription =
+                ConfirmationDescription.getConfirmationDescription(validTransactionDescription);
+
+        assertEquals(expectedConfirmationDesction, confirmationDescription);
+    }
+
+    @Test
+    @DisplayName("Get Confirmation Description - Invalid Transaction Description")
+    void getConfirmationDescriptionThrowsException() {
+
+        String invalidTransactionDescription = "invalidTransactionDescription";
+
+        assertThrows(UnsupportedTransactionConfirmationException.class, () ->
+                ConfirmationDescription.getConfirmationDescription(invalidTransactionDescription));
+    }
+
+}


### PR DESCRIPTION
Add ConfirmationDescription enum which provides a mapping between a transaction description and a confirmation description, along with relevant tests.

Required for SFA-708