### PR TITLE
Add Confirmation Transformer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
 
 		<sdk-manager-java.version>1.0.0-rc1</sdk-manager-java.version>
 
+		<lombok.version>1.18.0</lombok.version>
+
 		<spring-test.version>4.3.3.RELEASE</spring-test.version>
 
 		<junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
@@ -52,6 +54,13 @@
 			<groupId>uk.gov.companieshouse</groupId>
 			<artifactId>sdk-manager-java</artifactId>
 			<version>${sdk-manager-java.version}</version>
+		</dependency>
+
+		<!-- Lombok -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
 		</dependency>
 
 		<!-- Test Dependencies -->

--- a/src/main/java/uk/gov/companieshouse/transactions/web/model/confirmation/Confirmation.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/model/confirmation/Confirmation.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.transactions.web.model.confirmation;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Confirmation {
+
+    private String companyName;
+
+    private String companyNumber;
+
+    private String confirmationDescription;
+
+    private String closedAtDate;
+
+    private String closedAtTime;
+
+    private String transactionId;
+
+    private String closedBy;
+}

--- a/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/ConfirmationTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/ConfirmationTransformer.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.transactions.web.transformer.confirmation;
+
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.transactions.web.exception.UnsupportedTransactionConfirmationException;
+import uk.gov.companieshouse.transactions.web.model.confirmation.Confirmation;
+
+public interface ConfirmationTransformer {
+
+    /**
+     * Get the {@link Confirmation} model for a provided transaction
+     * @param transaction The transaction for which to retrieve a {@link Confirmation}
+     * @return A transaction confirmation
+     * @throws UnsupportedTransactionConfirmationException If the transaction cannot be mapped to
+     *         a confirmation
+     */
+    Confirmation getTransactionConfirmation(Transaction transaction)
+            throws UnsupportedTransactionConfirmationException;
+}

--- a/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImpl.java
@@ -31,23 +31,18 @@ public class ConfirmationTransformerImpl implements ConfirmationTransformer {
         Confirmation confirmation = new Confirmation();
 
         confirmation.setCompanyName(transaction.getCompanyName());
-
         confirmation.setCompanyNumber(transaction.getCompanyNumber());
 
         String confirmationDescription =
                 ConfirmationDescription.getConfirmationDescription(transaction.getDescription());
-
         confirmation.setConfirmationDescription(confirmationDescription);
 
         Instant closedInstant = Instant.parse(transaction.getClosedAt());
         LocalDateTime closedAt = LocalDateTime.ofInstant(closedInstant, ZoneOffset.UTC);
 
         confirmation.setClosedAtDate(closedAt.format(DATE_FORMATTER));
-
         confirmation.setClosedAtTime(closedAt.format(TIME_FORMATTER));
-
         confirmation.setTransactionId(transaction.getId());
-
         confirmation.setClosedBy(transaction.getClosedBy().get(EMAIL_KEY));
 
         return confirmation;

--- a/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImpl.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.transactions.web.transformer.confirmation.impl;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import org.omg.CORBA.PRIVATE_MEMBER;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.transactions.web.confirmation.ConfirmationDescription;
+import uk.gov.companieshouse.transactions.web.exception.UnsupportedTransactionConfirmationException;
+import uk.gov.companieshouse.transactions.web.model.confirmation.Confirmation;
+import uk.gov.companieshouse.transactions.web.transformer.confirmation.ConfirmationTransformer;
+
+@Component
+public class ConfirmationTransformerImpl implements ConfirmationTransformer {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("d MMMM yyyy");
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("h:mm a");
+
+    private static final String EMAIL_KEY = "email";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Confirmation getTransactionConfirmation(Transaction transaction) throws UnsupportedTransactionConfirmationException {
+
+        Confirmation confirmation = new Confirmation();
+
+        confirmation.setCompanyName(transaction.getCompanyName());
+
+        confirmation.setCompanyNumber(transaction.getCompanyNumber());
+
+        String confirmationDescription =
+                ConfirmationDescription.getConfirmationDescription(transaction.getDescription());
+
+        confirmation.setConfirmationDescription(confirmationDescription);
+
+        Instant closedInstant = Instant.parse(transaction.getClosedAt());
+        LocalDateTime closedAt = LocalDateTime.ofInstant(closedInstant, ZoneOffset.UTC);
+
+        confirmation.setClosedAtDate(closedAt.format(DATE_FORMATTER));
+
+        confirmation.setClosedAtTime(closedAt.format(TIME_FORMATTER));
+
+        confirmation.setTransactionId(transaction.getId());
+
+        confirmation.setClosedBy(transaction.getClosedBy().get(EMAIL_KEY));
+
+        return confirmation;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImpl.java
@@ -2,10 +2,8 @@ package uk.gov.companieshouse.transactions.web.transformer.confirmation.impl;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import org.omg.CORBA.PRIVATE_MEMBER;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.transactions.web.confirmation.ConfirmationDescription;

--- a/src/test/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImplTests.java
@@ -1,0 +1,110 @@
+package uk.gov.companieshouse.transactions.web.transformer.confirmation.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.transactions.web.exception.UnsupportedTransactionConfirmationException;
+import uk.gov.companieshouse.transactions.web.model.confirmation.Confirmation;
+import uk.gov.companieshouse.transactions.web.transformer.confirmation.ConfirmationTransformer;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ConfirmationTransformerImplTests {
+
+    private static final String COMPANY_NAME = "companyName";
+
+    private static final String COMPANY_NUMBER = "companyNumber";
+
+    private static final String VALID_TRANSACTION_DESCRIPTION = "Small Full Accounts";
+
+    private static final String EXPECTED_CONFIRMATION_DESCRIPTION = "Full accounts";
+
+    private static final String INVALID_TRANSACTION_DESCRIPTION = "invalidTransactionDescription";
+
+    private static final String CLOSED_AT_DATE_STRING = "2018-07-01T12:34:00.000Z";
+
+    private static final String EXPECTED_CONFIRMATION_CLOSED_DATE = "1 July 2018";
+
+    private static final String EXPECTED_CONFIRMATION_CLOSED_TIME = "12:34 PM";
+
+    private static final String TRANSACTION_ID = "transactionId";
+
+    private static final String CLOSED_BY = "closed@by.email";
+
+    private static final String EMAIL_KEY = "email";
+
+    private ConfirmationTransformer confirmationTransformer;
+
+    @BeforeEach
+    void setUp() {
+        confirmationTransformer = new ConfirmationTransformerImpl();
+    }
+
+    @Test
+    @DisplayName("Get Transaction Confirmation - Valid Transaction")
+    void getTransactionConfirmationSuccess() throws UnsupportedTransactionConfirmationException {
+
+        Confirmation confirmation =
+                confirmationTransformer.getTransactionConfirmation(constructValidTransaction());
+
+        assertEquals(COMPANY_NAME, confirmation.getCompanyName());
+        assertEquals(COMPANY_NUMBER, confirmation.getCompanyNumber());
+        assertEquals(EXPECTED_CONFIRMATION_DESCRIPTION, confirmation.getConfirmationDescription());
+        assertEquals(EXPECTED_CONFIRMATION_CLOSED_DATE, confirmation.getClosedAtDate());
+        assertEquals(EXPECTED_CONFIRMATION_CLOSED_TIME, confirmation.getClosedAtTime());
+        assertEquals(TRANSACTION_ID, confirmation.getTransactionId());
+        assertEquals(CLOSED_BY, confirmation.getClosedBy());
+    }
+
+    @Test
+    @DisplayName("Get Transaction Confirmation - Invalid Transaction")
+    void getTransactionConfirmationThrowsException() {
+
+        assertThrows(UnsupportedTransactionConfirmationException.class, () ->
+                confirmationTransformer.getTransactionConfirmation(constructInvalidTransaction()));
+    }
+
+    /**
+     * Construct a valid transaction record which can be mapped to a {@link Confirmation} model
+     * @return a valid transaction
+     */
+    private Transaction constructValidTransaction() {
+
+        Transaction transaction = new Transaction();
+
+        transaction.setCompanyName(COMPANY_NAME);
+        transaction.setCompanyNumber(COMPANY_NUMBER);
+        transaction.setDescription(VALID_TRANSACTION_DESCRIPTION);
+        transaction.setClosedAt(CLOSED_AT_DATE_STRING);
+        transaction.setId(TRANSACTION_ID);
+
+        Map<String, String> closedBy = new HashMap<>();
+        closedBy.put(EMAIL_KEY, CLOSED_BY);
+
+        transaction.setClosedBy(closedBy);
+
+        return transaction;
+    }
+
+    /**
+     * Construct a transaction record which cannot be mapped to a {@link Confirmation} model
+     * @return an invalid transaction
+     */
+    private Transaction constructInvalidTransaction() {
+
+        Transaction transaction = new Transaction();
+
+        transaction.setDescription(INVALID_TRANSACTION_DESCRIPTION);
+
+        return transaction;
+    }
+}


### PR DESCRIPTION
Add `ConfirmationTransformer` used to transform a transaction into a `Confirmation` model

Required for SFA-708