### PR TITLE
Add Piwik for Use in the Confirmation Page

### DIFF
--- a/src/main/java/uk/gov/companieshouse/transactions/web/controller/confirmation/ConfirmationController.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/controller/confirmation/ConfirmationController.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -21,8 +22,6 @@ public class ConfirmationController {
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(TransactionsWebApplication.APPLICATION_NAME_SPACE);
-
-    private static final String CONFIRMATION_PAGE = "transactionConfirmation";
 
     private static final String ERROR_PAGE = "error";
 
@@ -47,7 +46,7 @@ public class ConfirmationController {
 
             model.addAttribute("confirmation", confirmationService.getTransactionConfirmation(transaction));
 
-            return CONFIRMATION_PAGE;
+            return getTemplateName();
 
         } catch (ServiceException ex) {
 
@@ -56,4 +55,9 @@ public class ConfirmationController {
         }
     }
 
+    @ModelAttribute("templateName")
+    private static String getTemplateName() {
+
+        return "transactionConfirmation";
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ account.url=${ACCOUNT_LOCAL_URL}
 monitorGui.url=${CHS_MONITOR_GUI_URL}
 cdn.url=//${CDN_HOST}
 enquiries=mailto:enquiries@companieshouse.gov.uk
+piwik.url=${PIWIK_URL}
+piwik.siteId=${PIWIK_SITE_ID}

--- a/src/main/resources/templates/fragments/piwik.html
+++ b/src/main/resources/templates/fragments/piwik.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+    <head>
+        <title>Piwik</title>
+    </head>
+    <body>
+        <div th:fragment="piwik">
+            <script th:inline="javascript">
+                (function() {
+                    bindPiwikListener('transactions', /*[[${@environment.getProperty('piwik.url')}]]*/, /*[[${@environment.getProperty('piwik.siteId')}]]*/);
+                })();
+            </script>
+            <noscript>
+              <p>
+                <img th:src="@{{piwikUrl}/piwik.php?idsite={siteId}(piwikUrl=${@environment.getProperty('piwik.url')},
+                             siteId=${@environment.getProperty('piwik.site.id')})}" style="border:0;" alt="" />
+              </p>
+            </noscript>
+        </div>
+    </body>
+</html>

--- a/src/main/resources/templates/fragments/userBar.html
+++ b/src/main/resources/templates/fragments/userBar.html
@@ -9,10 +9,10 @@
             <nav class="content" role="navigation">
                 <ul id="navigation" class="mobile-hidden">
                     <li class="user" id="signed-in-user" th:text="${userEmail + ': '}" />
-                    <li><a th:href="@{{chsAccountUrl}/user/account(chsAccountUrl=${@environment.getProperty('account.url')})}" id="your-details">Your details</a></li>
-                    <li><a href="/user/transactions" id="your-filings">Your filings</a></li>
-                    <li><a th:href="@{{chsFollowUrl}/admin/monitor(chsFollowUrl=${@environment.getProperty('monitorGui.url')})}" id="companies-you-follow">Companies you follow</a></li>
-                    <li><a href="/signout" id="user-signout">Sign out</a></li>
+                    <li><a th:href="@{{chsAccountUrl}/user/account(chsAccountUrl=${@environment.getProperty('account.url')})}" id="your-details" class="piwik-event" data-event-id="Your details - top menu">Your details</a></li>
+                    <li><a href="/user/transactions" id="your-filings" class="piwik-event" data-event-id="Your filings - top menu">Your filings</a></li>
+                    <li><a th:href="@{{chsFollowUrl}/admin/monitor(chsFollowUrl=${@environment.getProperty('monitorGui.url')})}" id="companies-you-follow" class="piwik-event" data-event-id="Companies you follow">Companies you follow</a></li>
+                    <li><a href="/signout" id="user-signout" class="piwik-event" data-event-id="Sign out">Sign out</a></li>
                 </ul>
             </nav>
         </div>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title layout:title-pattern="$CONTENT_TITLE"></title>
+    <div id="templateName" th:attr="data-id=${templateName}" hidden></div>
     <link
         th:href="@{{cdnUrl}/stylesheets/assets-digital-cabinet-office-gov-uk-static/govuk-template.css?0.17.3(cdnUrl=${@environment.getProperty('cdn.url')})}"
         media="screen" rel="stylesheet" type="text/css" />
@@ -31,5 +32,7 @@
     <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-1.12.4.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/app/js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{{cdnUrl}/javascripts/app/piwik-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <div th:replace="fragments/piwik :: piwik"></div>
 </body>
 </html>

--- a/src/main/resources/templates/transactionConfirmation.html
+++ b/src/main/resources/templates/transactionConfirmation.html
@@ -49,7 +49,7 @@
         </p>
         <p id="contact-us">
           If you've not received the confirmation, check your spam or junk mail folder. You should
-          <a th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}">contact us</a>
+          <a th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}" class="piwik-event" data-event-id="Contact us">contact us</a>
           if you haven't had an email within 30 minutes.
         </p>
         <p id="second-email">
@@ -62,13 +62,13 @@
 
         <ul class="list" id="confirmation-next-steps">
           <li hidden="true" class="onlyJS">
-            <a id="confirmation-print-link" href="#" onClick="window.print();">Print this page for your records</a>
+            <a id="confirmation-print-link" href="#" onClick="window.print();" class="piwik-event" data-event-id="Print page">Print this page for your records</a>
           </li>
           <li>
-            <a id="confirmation-your-filings" href="/user/transactions">See your filings</a>
+            <a id="confirmation-your-filings" href="/user/transactions" class="piwik-event" data-event-id="Your filings - body">See your filings</a>
           </li>
           <li>
-            <a id="confirmation-company-overview" th:href="@{'/company/' + *{companyNumber}}">Return to company overview</a>
+            <a id="confirmation-company-overview" th:href="@{'/company/' + *{companyNumber}}" class="piwik-event" data-event-id="Return to company">Return to company overview</a>
           </li>
         </ul>
 

--- a/src/test/java/uk/gov/companieshouse/transactions/web/controller/confirmation/ConfirmationControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/transactions/web/controller/confirmation/ConfirmationControllerTests.java
@@ -50,6 +50,8 @@ public class ConfirmationControllerTests {
 
     private static final String CONFIRMATION_MODEL_ATTR = "confirmation";
 
+    private static final String TEMPLATE_NAME_ATTR = "templateName";
+
     private static final String ERROR_VIEW = "error";
 
     @BeforeEach
@@ -74,7 +76,8 @@ public class ConfirmationControllerTests {
         this.mockMvc.perform(get(CONFIRMATION_PATH))
                 .andExpect(view().name(CONFIRMATION_VIEW))
                 .andExpect(status().isOk())
-                .andExpect(model().attributeExists(CONFIRMATION_MODEL_ATTR));
+                .andExpect(model().attributeExists(CONFIRMATION_MODEL_ATTR))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_ATTR));
     }
 
     @Test


### PR DESCRIPTION
Add Piwik for use in the confirmation page.

Reliant on https://github.com/companieshouse/cdn.ch.gov.uk/pull/268

Resolves SFA-601