### PR TITLE
Make styling of the confirmation page consistent with the prototype

### DIFF
--- a/src/main/resources/templates/fragments/betaBanner.html
+++ b/src/main/resources/templates/fragments/betaBanner.html
@@ -4,10 +4,10 @@
         <title></title>
     </head>
     <body>
-        <div th:fragment="betaBanner" class="phase-banner">
-            <p>
-                <strong class="phase-tag">BETA</strong>
-                <span>This is a trial service. Help us improve it by
+        <div th:fragment="betaBanner" class="govuk-phase-banner">
+            <p class="govuk-phase-banner__content">
+                <strong class="govuk-tag govuk-phase-banner__content__tag">BETA</strong>
+                <span class="govuk-phase-banner__text">This is a trial service. Help us improve it by
                     <a id="feedback-link" href="https://www.research.net/r/chfiling" target="_blank">
                         <span class="visuallyhidden">This is a new service. Help us improve it by </span>
                         completing our quick survey

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -5,22 +5,13 @@
     </head>
     <body>
         <th:block th:fragment="header">
-            <header  role="banner" id="global-header" class="with-proposition">
-                <div class="header-wrapper">
+            <header  role="banner" id="global-header" class="govuk-header">
+                <div class="govuk-header__container govuk-width-container">
                     <div class="header-global">
-                        <div class="header-logo">
-                            <a href="/" title="Go to the GOV.UK homepage" id="logo" class="content">
-                                Companies House
+                        <div class="govuk-header__logo">
+                            <a href="/" title="Go to the companies house homepage" id="logo" class="govuk-header__link govuk-header__link--homepage">
+                                <span class="govuk-header__logotype-text"> Companies House </span>
                             </a>
-                        </div>
-                    </div>
-
-                    <div class="header-proposition">
-                        <div class="content">
-                            <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
-                            <nav id="proposition-menu">
-                                <a href="/" id="proposition-name"> File company accounts </a>
-                            </nav>
                         </div>
                     </div>
                 </div>

--- a/src/main/resources/templates/fragments/userBar.html
+++ b/src/main/resources/templates/fragments/userBar.html
@@ -5,7 +5,6 @@
     </head>
     <body>
         <div th:fragment="userBar" class="js-toggle-nav" id="global-nav">
-            <a href="#navigation" id="signed-in-user-href" class="js-header-toggle" th:text="${userEmail + ':'}"></a>
             <nav class="content" role="navigation">
                 <ul id="navigation" class="mobile-hidden">
                     <li class="user" id="signed-in-user" th:text="${userEmail + ': '}" />

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -6,13 +6,7 @@
     <title layout:title-pattern="$CONTENT_TITLE"></title>
     <div id="templateName" th:attr="data-id=${templateName}" hidden></div>
     <link
-        th:href="@{{cdnUrl}/stylesheets/assets-digital-cabinet-office-gov-uk-static/govuk-template.css?0.17.3(cdnUrl=${@environment.getProperty('cdn.url')})}"
-        media="screen" rel="stylesheet" type="text/css" />
-    <link
-        th:href="@{{cdnUrl}/stylesheets/application.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
-        media="all" rel="stylesheet" type="text/css" />
-    <link
-        th:href="@{{cdnUrl}/stylesheets/ch-accounts.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
+        th:href="@{{cdnUrl}/stylesheets/small-full-ch-accounts.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
         media="all" rel="stylesheet" type="text/css" />
     <link
         rel="icon"
@@ -22,11 +16,13 @@
 <body>
     <div class="entire-wrapper">
         <div th:replace="fragments/header :: header"></div>
-        <main id="content" role="main" class="two-column-accounts">
+        <div class="govuk-width-container">
             <div th:replace="fragments/betaBanner :: betaBanner"></div>
             <div th:replace="fragments/userBar :: userBar"></div>
-            <div layout:fragment="content"></div>
-        </main>
+            <main id="content" role="main" class="govuk-main-wrapper">
+                <div layout:fragment="content"></div>
+            </main>
+        </div>
     </div>
     <div th:replace="fragments/footer :: footer"></div>
     <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>

--- a/src/main/resources/templates/transactionConfirmation.html
+++ b/src/main/resources/templates/transactionConfirmation.html
@@ -12,55 +12,56 @@
 
   <form id="confirmation-form" th:action="@{''}" th:object="${confirmation}" class="form">
 
-    <div class="grid-row">
+    <div class="govuk-grid-row">
 
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
 
-        <div class="govuk-box-highlight" id="confirmation-details">
+        <div class="govuk-panel govuk-panel--confirmation" id="confirmation-details">
 
-          <p class="font-large" id="confirmation-company-name-number">
-            <strong th:text="*{companyName}"/>
-            <br/>
+          <div class="govuk-panel__body govuk-!-margin-bottom-6" id="confirmation-company-name-number">
             <strong>
+              <span class="uppercase" th:text="*{companyName}"/>
+              <br>
               Company number <span th:text="*{companyNumber}"/>
             </strong>
-          </p>
+          </div>
 
-          <p class="font-large" id="confirmation-description">
-            <strong>
-              <span th:text="*{confirmationDescription}"/> received
-            </strong>
-          </p>
+          <h2 class="govuk-panel__title" id="confirmation-description">
+            <span th:text="*{confirmationDescription}"/> received
+          </h2>
 
-          <p class="font-large" id="confirmation-closed-date-time">
-            on <strong class="bold-large" th:text="*{closedAtDate}"/> at <strong class="bold-large" th:text="*{closedAtTime}"/>
-          </p>
+          <div class="govuk-panel__body govuk-!-margin-bottom-6" id="confirmation-closed-date-time">
+            on
+            <span class="govuk-!-font-weight-bold" th:text="*{closedAtDate}"/>
+            at
+            <span class="govuk-!-font-weight-bold" th:text="*{closedAtTime}"/>
+          </div>
 
-          <p class="font-large" id="confirmation-reference">
-            Reference number
+          <div class="govuk-panel__body" id="confirmation-reference">
+            Your reference number
             <br/>
             <strong th:text="*{transactionId}"></strong>
-          </p>
+          </div>
 
         </div>
 
-        <p id="confirmation-email">
+        <p class="govuk-body" id="confirmation-email">
           We have sent you a confirmation email at <strong th:text="*{closedBy}"/> with your reference number.
         </p>
-        <p id="contact-us">
+        <p class="govuk-body" id="contact-us">
           If you've not received the confirmation, check your spam or junk mail folder. You should
           <a th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}" class="piwik-event" data-event-id="Contact us">contact us</a>
           if you haven't had an email within 30 minutes.
         </p>
-        <p id="second-email">
+        <p class="govuk-body" id="second-email">
           We'll send a second email to confirm that your filing has been processed (normally within 2 working days).
         </p>
 
-        <h1 class="heading-medium" id="confirmation-next-steps-heading">
+        <h1 class="govuk-heading-m" id="confirmation-next-steps-heading">
           What do you want to do next?
         </h1>
 
-        <ul class="list" id="confirmation-next-steps">
+        <ul class="govuk-list" id="confirmation-next-steps">
           <li hidden="true" class="onlyJS">
             <a id="confirmation-print-link" href="#" onClick="window.print();" class="piwik-event" data-event-id="Print page">Print this page for your records</a>
           </li>
@@ -72,7 +73,7 @@
           </li>
         </ul>
 
-        <p>
+        <p class="govuk-body">
           <span id="confirmation-feedback">This is a new service. Help us improve it by
             <a id="confirmation-feedback-link" href="https://www.research.net/r/chfiling" target="_blank">completing our quick survey</a>.
           </span>


### PR DESCRIPTION
Update stylesheet to reference the new `small-full-ch-accounts.css` file to bring the confirmation page inline with the prototype.

Resolves SFA-759