### PR TITLE
Fix Page Content Bleeding into Footer

### DIFF
--- a/src/main/resources/templates/fragments/betaBanner.html
+++ b/src/main/resources/templates/fragments/betaBanner.html
@@ -11,7 +11,7 @@
                     <a id="feedback-link" href="https://www.research.net/r/chfiling" target="_blank">
                         <span class="visuallyhidden">This is a new service. Help us improve it by </span>
                         completing our quick survey
-                    </a>.
+                    </a>
                 </span>
             </p>
         </div>

--- a/src/main/resources/templates/fragments/piwik.html
+++ b/src/main/resources/templates/fragments/piwik.html
@@ -4,7 +4,7 @@
         <title>Piwik</title>
     </head>
     <body>
-        <div th:fragment="piwik">
+        <div th:fragment="piwik" class="govuk-visually-hidden">
             <script th:inline="javascript">
                 (function() {
                     bindPiwikListener('transactions', /*[[${@environment.getProperty('piwik.url')}]]*/, /*[[${@environment.getProperty('piwik.siteId')}]]*/);

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -23,8 +23,8 @@
                 <div layout:fragment="content"></div>
             </main>
         </div>
+        <div class="push"></div>
     </div>
-    <div class="push"></div>
     <div th:replace="fragments/footer :: footer"></div>
     <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-1.12.4.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -24,6 +24,7 @@
             </main>
         </div>
     </div>
+    <div class="push"></div>
     <div th:replace="fragments/footer :: footer"></div>
     <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-1.12.4.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>

--- a/src/main/resources/templates/transactionConfirmation.html
+++ b/src/main/resources/templates/transactionConfirmation.html
@@ -69,6 +69,9 @@
             <a id="confirmation-your-filings" href="/user/transactions" class="piwik-event" data-event-id="Your filings - body">See your filings</a>
           </li>
           <li>
+            <a id="confirmation-start-new-filing" href="/" class="piwik-event" data-event-id="Start new filing">Start a new filing</a>
+          </li>
+          <li>
             <a id="confirmation-company-overview" th:href="@{'/company/' + *{companyNumber}}" class="piwik-event" data-event-id="Return to company">Return to company overview</a>
           </li>
         </ul>


### PR DESCRIPTION
Add `push` class div before the footer to force the footer down the page so that there's no 'bleed' from the main body.

Fixes bug raised in SFA-661