### PR TITLE
Change Time Display

### DIFF
--- a/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImpl.java
@@ -16,7 +16,7 @@ public class ConfirmationTransformerImpl implements ConfirmationTransformer {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("d MMMM yyyy");
 
-    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("h:mm a");
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("h:mma");
 
     private static final String EMAIL_KEY = "email";
 
@@ -39,7 +39,7 @@ public class ConfirmationTransformerImpl implements ConfirmationTransformer {
         LocalDateTime closedAt = LocalDateTime.ofInstant(closedInstant, ZoneOffset.UTC);
 
         confirmation.setClosedAtDate(closedAt.format(DATE_FORMATTER));
-        confirmation.setClosedAtTime(closedAt.format(TIME_FORMATTER));
+        confirmation.setClosedAtTime(closedAt.format(TIME_FORMATTER).toLowerCase());
         confirmation.setTransactionId(transaction.getId());
         confirmation.setClosedBy(transaction.getClosedBy().get(EMAIL_KEY));
 

--- a/src/test/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/transactions/web/transformer/confirmation/impl/ConfirmationTransformerImplTests.java
@@ -34,7 +34,7 @@ public class ConfirmationTransformerImplTests {
 
     private static final String EXPECTED_CONFIRMATION_CLOSED_DATE = "1 July 2018";
 
-    private static final String EXPECTED_CONFIRMATION_CLOSED_TIME = "12:34 PM";
+    private static final String EXPECTED_CONFIRMATION_CLOSED_TIME = "12:34pm";
 
     private static final String TRANSACTION_ID = "transactionId";
 


### PR DESCRIPTION
Change time display to remove the trailing space after the time, and make the 'am'/'pm' lowercase to comply with GDS standards.

Resolves SFA-879