### PR TITLE
Verify payment session tamper free

### DIFF
--- a/src/main/java/uk/gov/companieshouse/transactions/web/controller/confirmation/ConfirmationController.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/controller/confirmation/ConfirmationController.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.transactions.web.controller.confirmation;
 
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -16,6 +19,7 @@ import uk.gov.companieshouse.transactions.web.service.confirmation.ConfirmationS
 import uk.gov.companieshouse.transactions.web.service.transaction.TransactionsService;
 
 import javax.servlet.http.HttpServletRequest;
+import uk.gov.companieshouse.transactions.web.session.SessionService;
 
 @Controller
 @RequestMapping("/transaction/{transactionId}/confirmation")
@@ -26,16 +30,37 @@ public class ConfirmationController {
 
     private static final String ERROR_PAGE = "error";
 
+    private static final String PAYMENT_STATE = "payment_state";
+
     @Autowired
     private TransactionsService transactionsService;
 
     @Autowired
     private ConfirmationService confirmationService;
 
+    @Autowired
+    private SessionService sessionService;
+
     @GetMapping
     public String getConfirmation(@PathVariable String transactionId,
+                                  @RequestParam("state") Optional<String> paymentState,
                                   HttpServletRequest request,
                                   Model model) {
+
+        if (paymentState.isPresent()) {
+
+            Map<String, Object> sessionData = sessionService.getSessionDataFromContext();
+
+            String sessionPaymentState = (String) sessionData.get(PAYMENT_STATE);
+            sessionData.remove(PAYMENT_STATE);
+
+            if (!sessionPaymentState.equals(paymentState.get())) {
+
+                LOGGER.errorRequest(request, "Payment state appears to have been tampered! "
+                        + "Expected: " + sessionPaymentState + ", Received: " + paymentState.get());
+                return ERROR_PAGE;
+            }
+        }
 
         try {
             Transaction transaction = transactionsService.getTransaction(transactionId);

--- a/src/main/java/uk/gov/companieshouse/transactions/web/controller/confirmation/ConfirmationController.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/controller/confirmation/ConfirmationController.java
@@ -54,7 +54,7 @@ public class ConfirmationController {
             String sessionPaymentState = (String) sessionData.get(PAYMENT_STATE);
             sessionData.remove(PAYMENT_STATE);
 
-            if (!sessionPaymentState.equals(paymentState.get())) {
+            if (!paymentState.get().equals(sessionPaymentState)) {
 
                 LOGGER.errorRequest(request, "Payment state appears to have been tampered! "
                         + "Expected: " + sessionPaymentState + ", Received: " + paymentState.get());


### PR DESCRIPTION
When creating a payment session, a 'payment state' is cached on the user session (PR for company-accounts [here](https://github.com/companieshouse/company-accounts.web.ch.gov.uk/pull/320)).

Prior to rendering the confirmation page, this cached state is compared to a query parameter which holds reference to the payment session state. In the event of a mismatch, the error page is displayed since we infer that the payment state has been tampered with.

Required for SFA-1455