### PR TITLE
Change pom parent to use CH parent. Fixes sonar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>uk.gov.companieshouse</groupId>
   <artifactId>transactions.web.ch.gov.uk</artifactId>
   <version>unversioned</version>
   <packaging>jar</packaging>
@@ -14,15 +13,29 @@
 
   <parent>
     <groupId>uk.gov.companieshouse</groupId>
-    <artifactId>companies-house-spring-boot-parent</artifactId>
-    <version>1.2.0</version>
+    <artifactId>companies-house-parent</artifactId>
+    <version>1.3.0</version>
   </parent>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot-dependencies.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
 
+    <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
+    <spring-boot-maven-plugin.version>2.1.3.RELEASE</spring-boot-maven-plugin.version>
     <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
 
     <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
@@ -83,7 +96,6 @@
     <dependency>
       <groupId>nz.net.ultraq.thymeleaf</groupId>
       <artifactId>thymeleaf-layout-dialect</artifactId>
-      <version>${thymeleaf-layout-dialect.version}</version>
     </dependency>
 
     <!-- Session Handler -->
@@ -110,7 +122,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${spring-security-core.version}</version>
     </dependency>
 
     <dependency>
@@ -134,34 +145,29 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>${hamcrest.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest-library-version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>${spring-test.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit-jupiter-engine.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>${mockito-junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -223,22 +229,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${jacoco-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>default-prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
SonarQube was upgraded, and so we need to upgrade to use a more
 recent companies house parent pom, without this Sonar PR reports
 are broken.
Just changing to use a newer companies-house-spring-boot-parent
 did not work breaking lots of tests. We are not supposed to use that
 as a parent any more, so this is a chance to use the proper
 companies-house-parent.
Used dependencyManagement to get dependencies lost in parent change.
Removed versions from dependencies where they were already
 provided in that version by the parent.
Removed groupId tag, as that is provided by parent too.