### PR TITLE
Upgrade Spring Boot to 2.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,27 +34,27 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
 
-    <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
-    <spring-boot-maven-plugin.version>2.1.3.RELEASE</spring-boot-maven-plugin.version>
-    <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
+    <spring-boot-dependencies.version>2.5.5</spring-boot-dependencies.version>
+    <spring-boot-maven-plugin.version>2.5.5</spring-boot-maven-plugin.version>
+    <thymeleaf-layout-dialect.version>2.5.3</thymeleaf-layout-dialect.version>
 
     <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
     <sdk-manager-java.version>1.5.15</sdk-manager-java.version>
 
-    <spring-security-core.version>5.2.5.RELEASE</spring-security-core.version>
+    <spring-security-core.version>5.5.2</spring-security-core.version>
 
     <structured-logging.version>1.5.0-rc2</structured-logging.version>
 
-    <hamcrest.version>1.3</hamcrest.version>
+    <hamcrest.version>2.2</hamcrest.version>
 
-    <hamcrest-library-version>1.3</hamcrest-library-version>
+    <hamcrest-library-version>2.2</hamcrest-library-version>
 
-    <spring-test.version>4.3.3.RELEASE</spring-test.version>
+    <spring-test.version>5.3.10</spring-test.version>
 
-    <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
+    <junit-jupiter-engine.version>5.7.2</junit-jupiter-engine.version>
 
-    <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
+    <mockito-junit-jupiter.version>3.9.0</mockito-junit-jupiter.version>
 
     <common-web-java.version>1.5.0</common-web-java.version>
 
@@ -225,7 +225,7 @@
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>2.7.0</version>
+        <version>3.1.4</version>
         <configuration>
           <container>
             <expandClasspathDependencies>true</expandClasspathDependencies>


### PR DESCRIPTION
Upgrades spring boot to the latest stable version 2.5.5. In addition
to spring boot upgrade, it also updates other relevant libraries that
are managed by this spring boot version. It also upgrades to latest
version of jib maven plugin.

Resolves: BI-7374