### PR TITLE
ASM-1939 Upgrade to Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,367 +1,384 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>transactions.web.ch.gov.uk</artifactId>
-  <version>unversioned</version>
-  <packaging>jar</packaging>
+    <artifactId>transactions.web.ch.gov.uk</artifactId>
+    <version>unversioned</version>
+    <packaging>jar</packaging>
 
-  <name>transactions.web.ch.gov.uk</name>
-  <description>Web service to handle transaction data</description>
+    <name>transactions.web.ch.gov.uk</name>
+    <description>Web service to handle transaction data</description>
 
-  <parent>
-    <groupId>uk.gov.companieshouse</groupId>
-    <artifactId>companies-house-parent</artifactId>
-    <version>2.1.12</version>
-    <relativePath/>
-  </parent>
+    <parent>
+        <groupId>uk.gov.companieshouse</groupId>
+        <artifactId>companies-house-parent</artifactId>
+        <version>2.1.12</version>
+        <relativePath/>
+    </parent>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>21</java.version>
-    <spring-boot-dependencies.version>4.0.6</spring-boot-dependencies.version>
-    <spring-boot-maven-plugin.version>4.0.6</spring-boot-maven-plugin.version>
-    <thymeleaf-layout-dialect.version>3.4.0</thymeleaf-layout-dialect.version>
-    <log4j-bom.version>2.25.0</log4j-bom.version>
-    <hamcrest.version>3.0</hamcrest.version>
-    <junit-jupiter-engine.version>5.13.1</junit-jupiter-engine.version>
-    <mockito-junit-jupiter.version>5.18.0</mockito-junit-jupiter.version>
-    <json.version>20250517</json.version>
-    <opentelemetry-instrumentation-bom.version>2.28.0</opentelemetry-instrumentation-bom.version>
-    <commons-lang3.version>3.18.0</commons-lang3.version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>21</java.version>
 
-    <!-- Internal Dependencies -->
-    <common-web-java.version>3.0.40</common-web-java.version>
-    <java-session-handler.version>4.1.17</java-session-handler.version>
-    <sdk-manager-java.version>3.0.14</sdk-manager-java.version>
-    <structured-logging.version>3.0.38</structured-logging.version>
-    <web-security-java.version>3.1.6</web-security-java.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies -->
+        <spring-boot.version>4.0.6</spring-boot.version>
+        <!-- Source: https://mvnrepository.com/artifact/nz.net.ultraq.thymeleaf/thymeleaf-layout-dialect -->
+        <thymeleaf-layout-dialect.version>4.0.1</thymeleaf-layout-dialect.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-bom -->
+        <log4j-bom.version>2.26.0</log4j-bom.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->
+        <hamcrest.version>3.0</hamcrest.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
+        <mockito-junit-jupiter.version>5.23.0</mockito-junit-jupiter.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.json/json -->
+        <json.version>20251224</json.version>
+        <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom -->
+        <opentelemetry.version>2.28.1</opentelemetry.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+        <commons-lang3.version>3.20.0</commons-lang3.version>
 
-    <!-- Maven and Surefire plugins -->
-    <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
-    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-    <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
-    <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
+        <!-- Internal Dependencies -->
+        <common-web-java.version>5.0.2</common-web-java.version>
+        <java-session-handler.version>4.1.22</java-session-handler.version>
+        <sdk-manager-java.version>3.0.15</sdk-manager-java.version>
+        <structured-logging.version>3.0.57</structured-logging.version>
+        <web-security-java.version>3.1.17</web-security-java.version>
 
-    <!-- Repositories -->
-    <artifactoryResolveSnapshotRepo>libs-snapshot-local</artifactoryResolveSnapshotRepo>
-    <artifactoryResolveReleaseRepo>libs-release-local</artifactoryResolveReleaseRepo>
+        <!-- Maven and Surefire plugins -->
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-jar-plugin -->
+        <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+        <!-- Source: https://mvnrepository.com/artifact/com.google.cloud.tools/jib-maven-plugin -->
+        <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
 
-    <!-- Sonar config -->
-    <sonar.projectKey>uk.gov.companieshouse:transactions.web.ch.gov.uk</sonar.projectKey>
-    <sonar.projectName>transactions.web.ch.gov.uk</sonar.projectName>
-    <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
-    <sonar.login></sonar.login>
-    <sonar.password></sonar.password>
+        <!-- Repositories -->
+        <artifactoryResolveSnapshotRepo>libs-snapshot-local</artifactoryResolveSnapshotRepo>
+        <artifactoryResolveReleaseRepo>libs-release-local</artifactoryResolveReleaseRepo>
 
-    <!-- Vulnerability override versions -->
-    <kotlin-sdlib.override.version>2.3.21</kotlin-sdlib.override.version>
-    <okhttp.override.version>5.3.2</okhttp.override.version>
-    <log4j.override.version>2.26.0</log4j.override.version>
-    <tomcat-embed.override.version>10.1.55</tomcat-embed.override.version>
-  </properties>
+        <!-- Sonar config -->
+        <sonar.projectKey>uk.gov.companieshouse:transactions.web.ch.gov.uk</sonar.projectKey>
+        <sonar.projectName>transactions.web.ch.gov.uk</sonar.projectName>
+        <!--suppress UnresolvedMavenProperty -->
+        <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
+        <sonar.login/>
+        <sonar.password/>
 
-  <dependencyManagement>
+        <!-- Vulnerability override versions -->
+        <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom -->
+        <kotlin.version>2.3.21</kotlin.version>
+        <!-- Source: https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
+        <okhttp.version>5.3.2</okhttp.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <!-- CVE-2020-29582(5.3) -->
+            <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Source: https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp.version}</version>
+                <scope>compile</scope>
+            </dependency>
+
+            <!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
+            <!-- Addresses https://www.cve.org/CVERecord?id=CVE-2026-41284 - Can probably be removed after 03/06/2026 following Spring Boot 4.0.7 release          -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>11.0.22</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>11.0.22</version>
+                <scope>compile</scope>
+            </dependency>
+            <!-- END CVE           -->
+
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.6.0-jre</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-      <dependency>
-        <groupId>io.opentelemetry.instrumentation</groupId>
-        <artifactId>opentelemetry-instrumentation-bom</artifactId>
-        <version>${opentelemetry-instrumentation-bom.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${json.version}</version>
+        </dependency>
 
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>${log4j-bom.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
+        <!-- CVE-2025-48734 -->
+        <!-- Source: https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
+        </dependency>
 
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot-dependencies.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
 
-      <!-- CVE-2020-29582(5.3) -->
-      <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib -->
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib</artifactId>
-        <version>${kotlin-sdlib.override.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <!-- Source: https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>${okhttp.override.version}</version>
-        <scope>compile</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
 
-      <!-- CVE-2026-34477(6.3), CVE-2026-34479(6.9) -->
-      <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-to-slf4j -->
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-to-slf4j</artifactId>
-        <version>${log4j.override.version}</version>
-        <scope>compile</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
 
-      <!-- CVE-2026-34477(6.3), CVE-2026-34479(6.9) -->
-      <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${log4j.override.version}</version>
-        <scope>compile</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-opentelemetry</artifactId>
+        </dependency>
 
-      <!-- CVE-2026-41293(9.8), CVE-2026-41284(7.5), CVE-2026-43513(7.5), CVE-2026-43512(9.8), CVE-2026-42498(7.3), CVE-2026-43515(9.1) -->
-      <!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>${tomcat-embed.override.version}</version>
-        <scope>compile</scope>
-      </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-logback-appender-1.0 -->
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-logback-appender-1.0</artifactId>
+            <version>${opentelemetry.version}-alpha</version>
+            <scope>compile</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
-      <!-- CVE-2026-41293(9.8), CVE-2026-41284(7.5), CVE-2026-43513(7.5), CVE-2026-43512(9.8), CVE-2026-42498(7.3), CVE-2026-43515(9.1)  -->
-      <!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-websocket</artifactId>
-        <version>${tomcat-embed.override.version}</version>
-        <scope>compile</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
 
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>common-web-java</artifactId>
+            <version>${common-web-java.version}</version>
+        </dependency>
+
+        <!-- Thymeleaf Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>nz.net.ultraq.thymeleaf</groupId>
+            <artifactId>thymeleaf-layout-dialect</artifactId>
+            <version>${thymeleaf-layout-dialect.version}</version>
+        </dependency>
+
+        <!-- Session Handler -->
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>java-session-handler</artifactId>
+            <version>${java-session-handler.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- SDK Dependencies -->
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>sdk-manager-java</artifactId>
+            <version>${sdk-manager-java.version}</version>
+        </dependency>
+
+        <!-- Security dependencies -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>web-security-java</artifactId>
+            <version>${web-security-java.version}</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>structured-logging</artifactId>
+            <version>${structured-logging.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
-  </dependencyManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>${json.version}</version>
-    </dependency>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+                <configuration>
+                    <mainClass>uk.gov.companieshouse.transactions.web.TransactionsWebApplication</mainClass>
+                    <layout>ZIP</layout>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-    <!-- CVE-2025-48734 -->
-    <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-      <version>1.11.0</version>
-    </dependency>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <fork>true</fork>
+                    <meminitial>128m</meminitial>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <maxmem>512m</maxmem>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
 
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${commons-lang3.version}</version>
-    </dependency>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
 
-    <dependency>
-      <groupId>io.opentelemetry.instrumentation</groupId>
-      <artifactId>opentelemetry-spring-boot-starter</artifactId>
-    </dependency>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-    </dependency>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-logging</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>uk.gov.companieshouse</groupId>
-      <artifactId>common-web-java</artifactId>
-      <version>${common-web-java.version}</version>
-    </dependency>
-
-    <!-- Thymeleaf Dependencies -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-thymeleaf</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>nz.net.ultraq.thymeleaf</groupId>
-      <artifactId>thymeleaf-layout-dialect</artifactId>
-      <version>${thymeleaf-layout-dialect.version}</version>
-    </dependency>
-
-    <!-- Session Handler -->
-    <dependency>
-      <groupId>uk.gov.companieshouse</groupId>
-      <artifactId>java-session-handler</artifactId>
-      <version>${java-session-handler.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <!-- SDK Dependencies -->
-    <dependency>
-      <groupId>uk.gov.companieshouse</groupId>
-      <artifactId>sdk-manager-java</artifactId>
-      <version>${sdk-manager-java.version}</version>
-    </dependency>
-
-    <!-- Security dependencies -->
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-web</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-config</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>uk.gov.companieshouse</groupId>
-      <artifactId>web-security-java</artifactId>
-      <version>${web-security-java.version}</version>
-    </dependency>
-
-    <!-- Logging -->
-    <dependency>
-      <groupId>uk.gov.companieshouse</groupId>
-      <artifactId>structured-logging</artifactId>
-      <version>${structured-logging.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>${hamcrest.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-  </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring-boot-maven-plugin.version}</version>
-        <configuration>
-          <mainClass>uk.gov.companieshouse.transactions.web.TransactionsWebApplication</mainClass>
-          <layout>ZIP</layout>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven-compiler-plugin.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-          <fork>true</fork>
-          <meminitial>128m</meminitial>
-          <encoding>${project.build.sourceEncoding}</encoding>
-          <maxmem>512m</maxmem>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>${maven-jar-plugin.version}</version>
-        <configuration>
-          <archive>
-            <manifest>
-              <addClasspath>true</addClasspath>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surefire-plugin.version}</version>
-      </plugin>
-
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>com.google.cloud.tools</groupId>
-        <artifactId>jib-maven-plugin</artifactId>
-        <version>${jib-maven-plugin.version}</version>
-        <configuration>
-          <container>
-            <expandClasspathDependencies>true</expandClasspathDependencies>
-          </container>
-          <from>
-            <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-build-21:latest</image>
-          </from>
-          <to>
-            <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/transactions.web.ch.gov.uk:latest</image>
-          </to>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>${jib-maven-plugin.version}</version>
+                <configuration>
+                    <container>
+                        <expandClasspathDependencies>true</expandClasspathDependencies>
+                    </container>
+                    <from>
+                        <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-build-21:latest</image>
+                    </from>
+                    <to>
+                        <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/transactions.web.ch.gov.uk:latest</image>
+                    </to>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,15 +22,15 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>21</java.version>
-    <spring-boot-dependencies.version>3.5.14</spring-boot-dependencies.version>
-    <spring-boot-maven-plugin.version>3.5.14</spring-boot-maven-plugin.version>
+    <spring-boot-dependencies.version>4.0.6</spring-boot-dependencies.version>
+    <spring-boot-maven-plugin.version>4.0.6</spring-boot-maven-plugin.version>
     <thymeleaf-layout-dialect.version>3.4.0</thymeleaf-layout-dialect.version>
     <log4j-bom.version>2.25.0</log4j-bom.version>
     <hamcrest.version>3.0</hamcrest.version>
     <junit-jupiter-engine.version>5.13.1</junit-jupiter-engine.version>
     <mockito-junit-jupiter.version>5.18.0</mockito-junit-jupiter.version>
     <json.version>20250517</json.version>
-    <opentelemetry-instrumentation-bom.version>2.14.0</opentelemetry-instrumentation-bom.version>
+    <opentelemetry-instrumentation-bom.version>2.28.0</opentelemetry-instrumentation-bom.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
 
     <!-- Internal Dependencies -->
@@ -134,14 +134,6 @@
         <scope>compile</scope>
       </dependency>
 
-      <!-- CVE-2026-41293(9.8), CVE-2026-41284(7.5), CVE-2026-43513(7.5), CVE-2026-43512(9.8), CVE-2026-42498(7.3), CVE-2026-43515(9.1)  -->
-      <!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-el</artifactId>
-        <version>${tomcat-embed.override.version}</version>
-        <scope>compile</scope>
-      </dependency>
 
       <!-- CVE-2026-41293(9.8), CVE-2026-41284(7.5), CVE-2026-43513(7.5), CVE-2026-43512(9.8), CVE-2026-42498(7.3), CVE-2026-43515(9.1)  -->
       <!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
@@ -182,7 +174,7 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,17 +174,6 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webmvc</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 

--- a/src/main/java/uk/gov/companieshouse/transactions/web/OpenTelemetryAppenderInitializer.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/OpenTelemetryAppenderInitializer.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.transactions.web;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+class OpenTelemetryAppenderInitializer implements InitializingBean {
+
+    private final OpenTelemetry openTelemetry;
+
+    OpenTelemetryAppenderInitializer(OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        OpenTelemetryAppender.install(this.openTelemetry);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/transactions/web/security/WebSecurity.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/security/WebSecurity.java
@@ -9,9 +9,11 @@ import org.springframework.security.web.SecurityFilterChain;
 import uk.gov.companieshouse.csrf.config.ChsCsrfMitigationHttpSecurityBuilder;
 
 @EnableWebSecurity
+@Configuration(proxyBeanMethods=false)
 public class WebSecurity {
 
-    @Configuration
+    private WebSecurity(){}
+
     @Order(1)
     public static class CompanyAccountsSecurityFilterConfig {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,8 +7,13 @@ enquiries=mailto:enquiries@companieshouse.gov.uk
 piwik.url=${PIWIK_URL}
 piwik.siteId=${PIWIK_SITE_ID}
 
-management.endpoints.enabled-by-default=false
+management.endpoints.access.default=read_only
 management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.health=/transaction/healthcheck
 management.endpoint.health.show-details=never
-management.endpoint.health.enabled=true
+management.endpoints.web.exposure.include=health
+
+management.opentelemetry.logging.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/logs
+management.opentelemetry.tracing.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces
+management.otlp.metrics.export.url=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/metrics
+


### PR DESCRIPTION
## Headline Changes
- Upgraded the platform from Spring Boot `3.5.14` to `4.0.6`.
- Refreshed core observability/logging dependencies (OpenTelemetry and Log4j BOM versions).
- Updated internal Companies House libraries to current compatible versions.
- Applied/retained explicit security-driven overrides for vulnerable transitive components.

## Version Updates
### Framework and core libraries
- `org.springframework.boot:spring-boot-dependencies`: `3.5.14` -> `4.0.6`
- `nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect`: `3.4.0` -> `4.0.1`
- `org.apache.logging.log4j:log4j-bom`: `2.25.0` -> `2.26.0`
- `io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom`: `2.14.0` -> `2.28.1`
- `org.json:json`: `20250517` -> `20251224`
- `org.apache.commons:commons-lang3`: `3.18.0` -> `3.20.0`
- `org.mockito:mockito-junit-jupiter`: `5.18.0` -> `5.23.0`

### Internal dependencies
- `uk.gov.companieshouse:common-web-java`: `3.0.40` -> `5.0.2`
- `uk.gov.companieshouse:java-session-handler`: `4.1.17` -> `4.1.22`
- `uk.gov.companieshouse:sdk-manager-java`: `3.0.14` -> `3.0.15`
- `uk.gov.companieshouse:structured-logging`: `3.0.38` -> `3.0.57`
- `uk.gov.companieshouse:web-security-java`: `3.1.6` -> `3.1.17`

### Build plugin updates
- `maven-compiler-plugin`: `3.14.0` -> `3.15.0`
- `maven-surefire-plugin`: `3.5.3` -> `3.5.5`
- `maven-jar-plugin`: `3.4.2` -> `3.5.0`
- `jib-maven-plugin`: `3.4.6` -> `3.5.1`

## Dependency Set Changes
### Added
- `org.springframework.boot:spring-boot-starter-webmvc`
- `org.springframework.boot:spring-boot-starter-opentelemetry` (replaces old OTel starter)
- `io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0` (`${opentelemetry.version}-alpha`)
- `com.google.guava:guava` pinned in dependency management (`33.6.0-jre`)
- `org.jetbrains.kotlin:kotlin-bom` import (`2.3.21`) replacing direct stdlib override style

### Removed / replaced
- `io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter` removed in favor of Spring Boot 4 starter.
- Direct dependency management overrides for:
  - `org.apache.logging.log4j:log4j-to-slf4j`
  - `org.apache.logging.log4j:log4j-api`
- Tomcat override approach changed from property-based `10.1.55` (+ `tomcat-embed-el`) to explicit:
  - `org.apache.tomcat.embed:tomcat-embed-core:11.0.22`
  - `org.apache.tomcat.embed:tomcat-embed-websocket:11.0.22`

## Security / Risk Notes
- Branch history indicates CVE remediation commits were included for Kotlin, Log4j, Plexus, and Tomcat.
- `commons-beanutils:1.11.0` CVE mitigation remains present.
- A temporary Tomcat pin is documented in `pom.xml` pending next Spring Boot patch alignment.

