### PR TITLE
ASM-1939 Refactor application properties and HTML templates to use global link variables.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,7 @@
         <java.version>21</java.version>
 
         <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies -->
-        <spring-boot.version>4.0.6</spring-boot.version>
-        <!-- Source: https://mvnrepository.com/artifact/nz.net.ultraq.thymeleaf/thymeleaf-layout-dialect -->
-        <thymeleaf-layout-dialect.version>4.0.1</thymeleaf-layout-dialect.version>
+        <spring-boot.version>4.0.7</spring-boot.version>
         <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-bom -->
         <log4j-bom.version>2.26.0</log4j-bom.version>
         <!-- Source: https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->
@@ -111,22 +109,6 @@
                 <version>${okhttp.version}</version>
                 <scope>compile</scope>
             </dependency>
-
-            <!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
-            <!-- Addresses https://www.cve.org/CVERecord?id=CVE-2026-41284 - Can probably be removed after 03/06/2026 following Spring Boot 4.0.7 release          -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>11.0.22</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>11.0.22</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- END CVE           -->
 
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -214,7 +196,6 @@
         <dependency>
             <groupId>nz.net.ultraq.thymeleaf</groupId>
             <artifactId>thymeleaf-layout-dialect</artifactId>
-            <version>${thymeleaf-layout-dialect.version}</version>
         </dependency>
 
         <!-- Session Handler -->

--- a/src/main/java/uk/gov/companieshouse/transactions/web/controller/confirmation/GlobalModelAdvice.java
+++ b/src/main/java/uk/gov/companieshouse/transactions/web/controller/confirmation/GlobalModelAdvice.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.transactions.web.controller.confirmation;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalModelAdvice {
+
+    @Value("${contactUs.url}")
+    private String contactUsUrl;
+
+    @Value("${feedback.url}")
+    private String feedbackUrl;
+
+    @Value("${chs.url}")
+    private String chsUrl;
+
+    @Value("${developer.url}")
+    private String developerUrl;
+
+    @Value("${account.url}")
+    private String accountUrl;
+
+    @Value("${monitorGui.url}")
+    private String monitorGuiUrl;
+
+    @Value("${cdn.url}")
+    private String cdnUrl;
+
+    @Value("${enquiries}")
+    private String enquiries;
+
+    @Value("${policies.url}")
+    private String policiesUrl;
+
+    @Value("${piwik.url}")
+    private String piwikUrl;
+
+    @Value("${piwik.siteId}")
+    private String piwikSiteId;
+
+    @ModelAttribute("globalLinks")
+    public Map<String, String> getGlobalLinks() {
+        return Map.of(
+                "feedbackUrl", feedbackUrl,
+                "contactUsUrl", contactUsUrl,
+                "policiesUrl", policiesUrl,
+                "cookiesUrl", chsUrl + "/help/cookies",
+                "developerUrl", developerUrl,
+                "chsAccountUrl", accountUrl + "/user/account",
+                "monitorGuiUrl", monitorGuiUrl + "/admin/monitor",
+                "cdnUrl", cdnUrl,
+                "enquiries", "mailto:" + enquiries
+        );
+    }
+
+    @ModelAttribute("piwik")
+    public Map<String, String> getPiwikProperties() {
+        return Map.of(
+                "url", piwikUrl,
+                "siteId", piwikSiteId
+        );
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,9 +3,12 @@ developer.url=${DEVELOPER_URL}
 account.url=${ACCOUNT_LOCAL_URL}
 monitorGui.url=${CHS_MONITOR_GUI_URL}
 cdn.url=//${CDN_HOST}
-enquiries=mailto:enquiries@companieshouse.gov.uk
+enquiries=${ENQUIRY_EMAIL}
 piwik.url=${PIWIK_URL}
 piwik.siteId=${PIWIK_SITE_ID}
+feedback.url=${FEEDBACK_URL}
+contactUs.url=${CONTACT_US_URL}
+policies.url=${POLICIES_URL}
 
 management.endpoints.access.default=read_only
 management.endpoints.web.base-path=/

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html xmlns:th="http://www.thymeleaf.org"
+<html lang="en" xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layouts/baseLayout}">
 
@@ -8,6 +8,7 @@
         <title>Server error</title>
     </head>
     <body>
+        <!--/*@thymesVar id="globalLinks" type="java.util.Map<String, String>"*/-->
         <div layout:fragment="content">
 
             <div class="text">
@@ -17,9 +18,9 @@
             <p>Try again in a few moments.</p>
             <p>
                 If this problem continues please
-                <a th:href="@{{enquiries}(enquiries=${@environment.getProperty('enquiries')})}">email us</a>
+                <a th:href="${globalLinks.enquiries}">email us</a>
             </p>
-          
+
         </div>
     </body>
 </html>

--- a/src/main/resources/templates/fragments/betaBanner.html
+++ b/src/main/resources/templates/fragments/betaBanner.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
     <head>
         <title></title>
     </head>
@@ -8,7 +8,8 @@
             <p class="govuk-phase-banner__content">
                 <strong class="govuk-tag govuk-phase-banner__content__tag">BETA</strong>
                 <span class="govuk-phase-banner__text">This is a trial service. Help us improve it by
-                    <a id="feedback-link" th:href="${@environment.getProperty('feedback.url')}" target="_blank">
+                    <!--/*@thymesVar id="globalLinks" type="java.util.Map"*/-->
+                    <a id="feedback-link" th:href="${globalLinks.feedbackUrl}" target="_blank">
                         <span class="visuallyhidden">This is a new service. Help us improve it by </span>
                         completing our quick survey
                     </a>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
     <head>
         <title>Header</title>
     </head>
+    <!--/*@thymesVar id="globalLinks" type="java.util.Map<String, String>"*/-->
     <body>
         <footer th:fragment="footer" class="group js-footer" id="footer" role="contentinfo">
             <nav>
                 <div>
                     <ul>
-                        <li><a id="policies-link" href="http://resources.companieshouse.gov.uk/serviceInformation.shtml">Policies</a></li>
-                        <li><a id="cookies-link" th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">Cookies</a></li>
-                        <li><a id="contact-us-link" th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}">Contact us</a></li>
-                        <li><a id="developer-link" th:href="@{{developerUrl}/api/docs/(developerUrl=${@environment.getProperty('developer.url')})}">Developers</a></li>
+                        <li><a id="policies-link" th:href="${globalLinks.policiesUrl}">Policies</a></li>
+                        <li><a id="cookies-link" th:href="${globalLinks.cookiesUrl}">Cookies</a></li>
+                        <li><a id="contact-us-link" th:href="${globalLinks.contactUsUrl}">Contact us</a></li>
+                        <li><a id="developer-link" th:href="${globalLinks.developerUrl}">Developers</a></li>
                     </ul>
                 </div>
             </nav>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
     <head>
         <title>Header</title>
     </head>

--- a/src/main/resources/templates/fragments/piwik.html
+++ b/src/main/resources/templates/fragments/piwik.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
     <head>
         <title>Piwik</title>
     </head>
@@ -7,13 +7,12 @@
         <div th:fragment="piwik" class="govuk-visually-hidden">
             <script th:inline="javascript">
                 (function() {
-                    bindPiwikListener('transactions', /*[[${@environment.getProperty('piwik.url')}]]*/, /*[[${@environment.getProperty('piwik.siteId')}]]*/);
+                    bindPiwikListener('transactions', /*[[${piwik.url}]]*/, /*[[${piwik.siteId}]]*/);
                 })();
             </script>
             <noscript>
               <p>
-                <img th:src="@{{piwikUrl}/piwik.php?idsite={siteId}(piwikUrl=${@environment.getProperty('piwik.url')},
-                             siteId=${@environment.getProperty('piwik.site.id')})}" style="border:0;" alt="" />
+                <img th:src="@{{piwikUrl}/piwik.php?idsite={siteId}(piwikUrl=${piwik.url},siteId=${piwik.siteId})}" style="border:0;" alt="" />
               </p>
             </noscript>
         </div>

--- a/src/main/resources/templates/fragments/userBar.html
+++ b/src/main/resources/templates/fragments/userBar.html
@@ -1,16 +1,17 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
     <head>
         <title>User Bar</title>
     </head>
     <body>
+        <!--/*@thymesVar id="globalLinks" type="java.util.Map<String, String>"*/-->
         <div th:fragment="userBar" class="js-toggle-nav" id="global-nav">
             <nav class="content" role="navigation">
                 <ul id="navigation" class="mobile-hidden">
                     <li class="user" id="signed-in-user" th:text="${userEmail + ': '}" />
-                    <li><a th:href="@{{chsAccountUrl}/user/account(chsAccountUrl=${@environment.getProperty('account.url')})}" id="your-details" class="piwik-event" data-event-id="Your details - top menu">Your details</a></li>
+                    <li><a th:href="${globalLinks.chsAccountUrl}" id="your-details" class="piwik-event" data-event-id="Your details - top menu">Your details</a></li>
                     <li><a href="/user/transactions" id="your-filings" class="piwik-event" data-event-id="Your filings - top menu">Your filings</a></li>
-                    <li><a th:href="@{{chsFollowUrl}/admin/monitor(chsFollowUrl=${@environment.getProperty('monitorGui.url')})}" id="companies-you-follow" class="piwik-event" data-event-id="Companies you follow">Companies you follow</a></li>
+                    <li><a th:href="${globalLinks.monitorGuiUrl}" id="companies-you-follow" class="piwik-event" data-event-id="Companies you follow">Companies you follow</a></li>
                     <li><a href="/signout" id="user-signout" class="piwik-event" data-event-id="Sign out">Sign out</a></li>
                 </ul>
             </nav>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<!--/*@thymesVar id="globalLinks" type="java.util.Map"*/-->
 <head>
     <meta charset="UTF-8">
     <title layout:title-pattern="$CONTENT_TITLE"></title>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -5,21 +5,14 @@
     <meta charset="UTF-8">
     <title layout:title-pattern="$CONTENT_TITLE"></title>
     <div id="templateName" th:attr="data-id=${templateName}" hidden></div>
-    <link
-        th:href="@{{cdnUrl}/stylesheets/chs-styles.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
-        media="all" rel="stylesheet" type="text/css" />
-    <link
-        th:href="@{{cdnUrl}/stylesheets/chs-print-styles.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
-        media="print" rel="stylesheet" type="text/css" />
-    <link
-        rel="icon"
-        th:href="@{{cdnUrl}/images/favicon.ico?0.17.3(cdnUrl=${@environment.getProperty('cdn.url')})}"
-        type="image/x-icon" />
+    <link th:href="${globalLinks.cdnUrl + '/stylesheets/chs-styles.css'}" media="all" rel="stylesheet" type="text/css" />
+    <link th:href="${globalLinks.cdnUrl + '/stylesheets/chs-print-styles.css'}" media="print" rel="stylesheet" type="text/css" />"
+    <link rel="icon" th:href="${globalLinks.cdnUrl + '/images/favicon.ico?0.17.3'}" type="image/x-icon" />
 
     <script th:inline="javascript">
         window.SERVICE_NAME = 'transactions-web'
-        window.PIWIK_URL = [[${@environment.getProperty('piwik.url')}]];
-        window.PIWIK_SITE_ID = [[${@environment.getProperty('piwik.siteId')}]];
+        window.PIWIK_URL = [[${piwik.url}]];
+        window.PIWIK_SITE_ID = [[${piwik.siteId}]];
     </script>
 
 </head>
@@ -40,12 +33,12 @@
         <div class="push"></div>
     </div>
     <div th:replace="~{fragments/footer :: footer}"></div>
-    <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-1.12.4.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/app/js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/app/piwik-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/piwik-only-cookie-consent.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="${globalLinks.cdnUrl + '/javascripts/vendor/require.js'}" type="text/javascript"></script>
+    <script th:src="${globalLinks.cdnUrl + '/javascripts/vendor/jquery-1.12.4.min.js'}" type="text/javascript"></script>
+    <script th:src="${globalLinks.cdnUrl + '/javascripts/app/js-enable.js'}" type="text/javascript"></script>
+    <script th:src="${globalLinks.cdnUrl + '/javascripts/app/piwik-enable.js'}" type="text/javascript"></script>
+    <script th:src="${globalLinks.cdnUrl + '/javascripts/app/cookie-consent/cookie-consent-1.0.0.js'}" type="text/javascript"></script>
+    <script th:src="${globalLinks.cdnUrl + '/javascripts/app/cookie-consent/piwik-only-cookie-consent.js'}" type="text/javascript"></script>
 
 </body>
 </html>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -6,7 +6,7 @@
     <title layout:title-pattern="$CONTENT_TITLE"></title>
     <div id="templateName" th:attr="data-id=${templateName}" hidden></div>
     <link th:href="${globalLinks.cdnUrl + '/stylesheets/chs-styles.css'}" media="all" rel="stylesheet" type="text/css" />
-    <link th:href="${globalLinks.cdnUrl + '/stylesheets/chs-print-styles.css'}" media="print" rel="stylesheet" type="text/css" />"
+    <link th:href="${globalLinks.cdnUrl + '/stylesheets/chs-print-styles.css'}" media="print" rel="stylesheet" type="text/css" />
     <link rel="icon" th:href="${globalLinks.cdnUrl + '/images/favicon.ico?0.17.3'}" type="image/x-icon" />
 
     <script th:inline="javascript">

--- a/src/main/resources/templates/transactionConfirmation.html
+++ b/src/main/resources/templates/transactionConfirmation.html
@@ -2,14 +2,16 @@
 
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{layouts/baseLayout}">
+      layout:decorate="~{layouts/baseLayout}" lang="en">
 
 <head>
   <title>Confirmation</title>
 </head>
 <body>
+<!--/*@thymesVar id="globalLinks" type="java.util.Map<String, String>"*/-->
 <div id="confirmation-main-content" layout:fragment="content">
 
+  <!--/*@thymesVar id="confirmation" type="uk.gov.companieshouse.transactions.web.model.confirmation.Confirmation"*/-->
   <form id="confirmation-form" th:action="@{''}" th:object="${confirmation}" class="form">
 
     <div class="govuk-grid-row">
@@ -50,7 +52,7 @@
         </p>
         <p class="govuk-body" id="contact-us">
           If you've not received the confirmation, check your spam or junk mail folder. You should
-          <a th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}" class="piwik-event" data-event-id="Contact us">contact us</a>
+          <a th:href="${globalLinks.contactUsUrl}" class="piwik-event" data-event-id="Contact us">contact us</a>
           if you haven't had an email within 30 minutes.
         </p>
         <p class="govuk-body" id="second-email">
@@ -78,7 +80,7 @@
 
         <p class="govuk-body">
           <span id="confirmation-feedback">This is a new service. Help us improve it by
-            <a id="confirmation-feedback-link" th:href="${@environment.getProperty('feedback.url')}" target="_blank">completing our quick survey</a>.
+            <a id="confirmation-feedback-link" th:href="${globalLinks.feedbackUrl}" target="_blank">completing our quick survey</a>.
           </span>
         </p>
 

--- a/src/test/java/uk/gov/companieshouse/transactions/web/controller/confirmation/GlobalModelAdviceTests.java
+++ b/src/test/java/uk/gov/companieshouse/transactions/web/controller/confirmation/GlobalModelAdviceTests.java
@@ -1,0 +1,86 @@
+package uk.gov.companieshouse.transactions.web.controller.confirmation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalModelAdviceTests {
+
+    private GlobalModelAdvice advice;
+
+    @BeforeEach
+    void setup() {
+        advice = new GlobalModelAdvice();
+        ReflectionTestUtils.setField(advice, "contactUsUrl", "https://www.gov.uk/help/contact-us");
+        ReflectionTestUtils.setField(advice, "feedbackUrl", "https://example.com/feedback");
+        ReflectionTestUtils.setField(advice, "chsUrl", "https://www.gov.uk");
+        ReflectionTestUtils.setField(advice, "developerUrl", "https://developer.company-information.service.gov.uk");
+        ReflectionTestUtils.setField(advice, "accountUrl", "https://account.company-information.service.gov.uk");
+        ReflectionTestUtils.setField(advice, "monitorGuiUrl", "https://monitor.company-information.service.gov.uk");
+        ReflectionTestUtils.setField(advice, "cdnUrl", "//cdn.ch.gov.uk");
+        ReflectionTestUtils.setField(advice, "enquiries", "enquiries@companieshouse.gov.uk");
+        ReflectionTestUtils.setField(advice, "policiesUrl", "https://resources.companieshouse.gov.uk/serviceInformation.shtml");
+        ReflectionTestUtils.setField(advice, "piwikUrl", "https://analytics.example.com");
+        ReflectionTestUtils.setField(advice, "piwikSiteId", "42");
+    }
+
+    @Test
+    @DisplayName("Global links include configured and derived values")
+    void getGlobalLinksIncludesConfiguredAndDerivedValues() {
+        Map<String, String> links = advice.getGlobalLinks();
+
+        assertEquals("https://example.com/feedback", links.get("feedbackUrl"));
+        assertEquals("https://www.gov.uk/help/contact-us", links.get("contactUsUrl"));
+        assertEquals("https://resources.companieshouse.gov.uk/serviceInformation.shtml", links.get("policiesUrl"));
+        assertEquals("https://www.gov.uk/help/cookies", links.get("cookiesUrl"));
+        assertEquals("https://developer.company-information.service.gov.uk", links.get("developerUrl"));
+        assertEquals("https://account.company-information.service.gov.uk/user/account", links.get("chsAccountUrl"));
+        assertEquals("https://monitor.company-information.service.gov.uk/admin/monitor", links.get("monitorGuiUrl"));
+        assertEquals("//cdn.ch.gov.uk", links.get("cdnUrl"));
+        assertEquals("mailto:enquiries@companieshouse.gov.uk", links.get("enquiries"));
+    }
+
+    @Test
+    @DisplayName("Global links enquiries value is always prefixed with mailto")
+    void getGlobalLinksAlwaysPrefixesEnquiriesWithMailto() {
+        ReflectionTestUtils.setField(advice, "enquiries", "mailto:enquiries@companieshouse.gov.uk");
+
+        Map<String, String> links = advice.getGlobalLinks();
+
+        assertEquals("mailto:mailto:enquiries@companieshouse.gov.uk", links.get("enquiries"));
+    }
+
+    @Test
+    @DisplayName("Global links creation fails when any configured value is null")
+    void getGlobalLinksThrowsWhenAnyConfiguredValueIsNull() {
+        ReflectionTestUtils.setField(advice, "feedbackUrl", null);
+
+        assertThrows(NullPointerException.class, () -> advice.getGlobalLinks());
+    }
+
+    @Test
+    @DisplayName("Piwik properties include configured url and site id")
+    void getPiwikPropertiesIncludesConfiguredValues() {
+        Map<String, String> piwikProperties = advice.getPiwikProperties();
+
+        assertEquals("https://analytics.example.com", piwikProperties.get("url"));
+        assertEquals("42", piwikProperties.get("siteId"));
+    }
+
+    @Test
+    @DisplayName("Piwik properties creation fails when url is null")
+    void getPiwikPropertiesThrowsWhenUrlIsNull() {
+        ReflectionTestUtils.setField(advice, "piwikUrl", null);
+
+        assertThrows(NullPointerException.class, () -> advice.getPiwikProperties());
+    }
+}
+


### PR DESCRIPTION
## Overview
This PR addresses critical template rendering errors introduced by the Spring Boot 4 upgrade. Spring Boot 4 enforces stricter security policies in Thymeleaf templates, preventing instantiation of objects and access to static classes/parameters. This change refactors the application to use a centralized, server-side model provider instead.

## Jira Ticket
**[ASM-1939](https://companieshouse.atlassian.net/browse/ASM-1939)** - Fix template errors following Spring Boot 4 upgrade

## Problem Statement
After upgrading to Spring Boot 4, the application experienced template rendering failures with the error:
```
Instantiation of new objects and access to static classes or parameters is forbidden in this context
```

This was triggered by Thymeleaf expressions in templates attempting to access environment properties directly via `@environment.getProperty()`, which is now prohibited for security reasons.

## Solution
Introduced a centralized `GlobalModelAdvice` component that:
- Injects application configuration from `application.properties`
- Provides all URLs and global configuration as model attributes
- Makes these attributes available to all Thymeleaf templates without requiring template-level property access
- Follows Spring's best practice of handling configuration at the controller/service layer rather than in views

[ASM-1939]: https://companieshouse.atlassian.net/browse/ASM-1939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ